### PR TITLE
Addition of '#' for six digit hex codes

### DIFF
--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -204,6 +204,11 @@ function colorChanged(input) {
 	var display = isForeground? foregroundDisplay : backgroundDisplay;
 	
 	var previousColor = getComputedStyle(display).backgroundColor;
+
+	// Match a 6 digit hex code, add a hash in front.
+	if(input.value.match(/^[0-9a-f]{6}$/i)) {
+		input.value = '#' + input.value;
+	}
 	
 	display.style.background = input.value;
 	


### PR DESCRIPTION
When copying hex codes from Photoshop, Fireworks and other graphics packages (which is often more convenient than using rgb and the like), '#' usually isn't prepended. This adds a conditional that matches only those six digit hex codes and automatically adds the '#' for convenience sake.
