### PR TITLE
Fix lower bound

### DIFF
--- a/color.js
+++ b/color.js
@@ -140,14 +140,23 @@ _.prototype = {
 		    
 		var max = Math.max(onBlack, onWhite);
 		
+		// This is here for backwards compatibility and not used to calculate
+		// `min`.  Note that there may be other colors with a closer luminance to
+		// `color` if they have a different hue than `this`.
 		var closest = this.rgb.map(function(c, i) {
 			return Math.min(Math.max(0, (color.rgb[i] - c * alpha)/(1-alpha)), 255);
 		});
 		
 		closest = new _(closest);
 
-		var min = this.overlayOn(closest).contrast(color).ratio;
-				
+		var min = 1;
+		if (this.overlayOn(_.BLACK).luminance > color.luminance) {
+			min = onBlack;
+		}
+		else if (this.overlayOn(_.WHITE).luminance < color.luminance) {
+			min = onWhite;
+		}
+
 		return {
 			ratio: Math.round((min + max) / 2, 2),
 			error: Math.round((max - min) / 2, 2),


### PR DESCRIPTION
I think I found an issue with the way the lower bound is calculated. Here is an example:

Say the foreground color is rgb(0,0,255) and the background color is rgba(255,255,0,0.5). With the existing approach a "closest" color is calculated as rgb(-255,-255,510) and then clipped to rgb(0,0,255). The overlayed background color than is rgb(128,128,128) which has a contrast of 2.2 to the foreground color.

To proof that this is not the actual lower bound I can use rgb(0,0,0) as backdrop color: The overlayed background color in this case is rgb(128,128,0) which has a contrast of 2 to the foreground color.

The issue with the existing algorithm is that it clips each color channel individually. In other words: Only colors with a similar hue are considered for `closest`. This ignores the fact that hue has a significant impact on luminence.

The algorithm I propose mostly ignores the individual color channels and instead uses the foreground luminance and the maximum and minimum luminances of the background (overlayed over white and black respectively).

Since the luminance function is continuous, we can assume that for each background luminance between the minimum and maxiumum values there exists a backdrop color that can produce it.  There may not be a perfect match because we are dealing with a discrete color space, but we should
get close enough for all practical considerations.

So if the foreground luminance is somewhere in that range, the lower bound for contrast is 1 (minimal). If it is not, we use the closest value for calculating the contrast resulting in `min(onBlack, onWhite)`.
