### PR TITLE
Increase pass rate to two decimal places: #13

### DIFF
--- a/color.js
+++ b/color.js
@@ -11,6 +11,20 @@ Math.round = (function(){
 	};
 })();
 
+// Extend Math.floor to allow for precision
+Math.floor = (function(){
+	var floor = Math.floor;
+
+	return function (number, decimals) {
+		decimals = +decimals || 0;
+
+		var multiplier = Math.pow(10, decimals);
+
+		return floor(number * multiplier) / multiplier;
+	};
+})();
+
+
 // Simple class for handling sRGB colors
 (function(){
 

--- a/color.js
+++ b/color.js
@@ -122,7 +122,7 @@ _.prototype = {
 				ratio = 1 / ratio;
 			}
 
-			ratio = Math.round(ratio, 1);
+			ratio = Math.round(ratio, 2);
 
 			return {
 				ratio: ratio,

--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -123,13 +123,26 @@ function update() {
 			error.title = '';
 		}
 
+			var precise = document.createElement('p');
+			precise.className = 'precise-value';
+			precise.textContent = 'Precise value: ' + contrast.ratio;
+
 		if (classes.length <= 1) {
-			results.textContent = messages[classes[0]];
+
+			results.textContent = '';
+			results.appendChild(precise);
+
+			var p = document.createElement('p');
+			p.textContent = messages[classes[0]];
+			results.appendChild(p);
+
 			output.style.backgroundImage = '';
 			output.style.backgroundColor = levels[classes[0]].color;
 		}
 		else {
 			var fragment = document.createDocumentFragment();
+
+			fragment.appendChild(precise);
 
 			var p = document.createElement('p');
 			p.textContent = messages.semitransparent;

--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -110,7 +110,7 @@ function update() {
 			}
 		}
 
-		$('strong', output).textContent = contrast.ratio;
+		$('strong', output).textContent = Math.floor(contrast.ratio, 1);
 
 		var error = $('.error', output);
 

--- a/style.css
+++ b/style.css
@@ -138,6 +138,10 @@ output {
 			font-size: 45%;
 			letter-spacing: normal;
 		}
+
+.precise-value {
+	font-weight: bold;
+}		
 	
 .color-display {
 	position: fixed;


### PR DESCRIPTION
I've taken a stab at #13 . 
In this version all the math is done on a ratio rounded to 2 decimal places.
The large number that displays the ratio is floored to 1 decimal place.
The tooltip shows the 2 decimal place value.

eg:
background: white / text color: hsla(200,0%,0%,.414)
On current version marks as passed (AA above 18pt). Shows a value of '3' in main bubble.
http://leaverou.github.io/contrast-ratio/#hsla%28200%2C0%25%2C0%25%2C.414%29-on-white

On my version marks as fail. Shows a value of 2.9 in main bubble. In tooltip it says 'precise value: 2.96'.
https://chrisboon.github.io/contrast-ratio/#hsla%28200%2C0%25%2C0%25%2C.414%29-on-white 

Honestly, whilst the code works I'm not sure this is a better experience than what you have now. Figured it was worth coding up and letting people decide though.
