### PR TITLE
Fix mixed content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,12 +49,12 @@
 
 <footer></footer>
 
-<script src="https://leaverou.github.com/incrementable/incrementable.js" id="incrementable" async></script>
+<script src="https://leaverou.github.io/incrementable/incrementable.js" id="incrementable" async></script>
 <script src="color.js"></script>
 <script src="contrast-ratio.js"></script>
 
 <script>_gaq = [['_setAccount', 'UA-117109922-1'], ['_trackPageview']];</script>
-<script src="http://www.google-analytics.com/ga.js" async></script>
+<script src="https://www.google-analytics.com/ga.js" async></script>
 
 <div class="social">
 	<a class="github-button" href="https://github.com/leaverou/contrast-ratio" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star leaverou/contrast-ratio on GitHub">Star</a>


### PR DESCRIPTION
There were 2 mixed content warning when loading the page on HTTPS:

- GA was loaded on HTTP, which was totally unnecessary as they totally support HTTPS (and even recommend it)
- the legacy `leaverou.github.com` domain of GH Pages redirects to leaverou.github.io (they made this change years ago), but the redirection does not preserve the scheme and always use HTTP. Moving to the actual GH Pages domain allows using HTTPS properly