### PR TITLE
Implement accessibility in the output tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 	<input id="foreground" value="hsla(200,0%,0%,.7)" />
 </label>
 
-<output tabindex="0">
+<output tabindex="0" aria-live="polite">
 	<strong>?</strong>
 	<span class="error"></span>
 </output>


### PR DESCRIPTION
There is a need to put aria-live="polite" in the output tag, so anyone who uses screen readers has access to contrast feedback.