### PR TITLE
Automatically add # hash when matches 3-digit hex codes

### DIFF
--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -214,8 +214,8 @@ function colorChanged(input) {
 
 	var previousColor = getComputedStyle(display).backgroundColor;
 
-	// Match a 6 digit hex code, add a hash in front.
-	if (input.value.match(/^[0-9a-f]{6}$/i)) {
+	// Match a 3 or 6 digit hex code, add a hash in front.
+	if (input.value.match(/^[0-9a-f]{3}$/i) || input.value.match(/^[0-9a-f]{6}$/i)){
 		input.value = "#" + input.value;
 	}
 

--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -214,8 +214,10 @@ function colorChanged(input) {
 
 	var previousColor = getComputedStyle(display).backgroundColor;
 
-	// Match a 3 or 6 digit hex code, add a hash in front.
-	if (input.value.match(/^[0-9a-f]{3}$/i) || input.value.match(/^[0-9a-f]{6}$/i)){
+	// Add hash to front of 3, 4, 6, and 8 digit hex codes.
+	var accepted_matches = [3, 4, 6, 8]
+	var match_result = input.value.match(/^[0-9a-f]{3,8}$/i)
+	if (match_result && accepted_matches.includes(match_result[0].length)){
 		input.value = "#" + input.value;
 	}
 


### PR DESCRIPTION
I noticed that it already recognizes 3-digit hex colors like `#000` when manually adding hash in front of the code, but it would be more convenient if the hash were automatically added like it is for 6-digit codes. I do not expect this to interfere with entry of any other method of color entry, including:
* `red`
* `hsl(1,1,1)`
* `rgba(0,0,0,0)`.