### PR TITLE
Bold, Italic, and Bold Italic

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
 <section class="color-display" id="backgroundDisplay">
 	<h1>How to use</h1>
 	<p>As you type, the contrast ratio indicated will update. Hover over the circle to get more detailed information. When semi-transparent colors are involved as backgrounds, the contrast ratio will have an error margin, to account for the different colors they may be over.</p>
-	<p style="font-family: Garamond, 'Palatino Linotype', Georgia, serif;">This sample text attempts to visually demonstrate how readable this color combination is, for normal or <strong>bold</strong> text of various sizes and font styles.</p>
-	<p style="font-family: Garamond, 'Palatino Linotype', Georgia, serif;font-style:italic;">This sample text attempts to visually demonstrate how readable this color combination is, for Italic font styles.</p>
+	<p style="font-family: Garamond, 'Palatino Linotype', Georgia, serif;">This sample text attempts to visually demonstrate how readable this color combination is, for normal, <span style="font-style: italic;">italic</span>, <span style="font-weight: bold;">bold</span>, or <span style="font-style: italic; font-weight: bold;">bold italic</span> text of various sizes and font styles.</p>
 	<p style="font-size: 11pt;"><strong>Hint:</strong> Press the up and down keyboard arrows while over a number inside a functional color notation. Watch it increment/decrement. Try with the Shift or Alt key too!</p>
 	<footer>
 		By <a href="http://lea.verou.me" rel="noopener" target="_blank">Lea Verou</a>


### PR DESCRIPTION
Hey! This is just a small change to accommodate the comment (https://github.com/LeaVerou/contrast-ratio/pull/38#issuecomment-712120847) you made on https://github.com/LeaVerou/contrast-ratio/pull/38.

> This sample text attempts to visually demonstrate how readable this color combination is, for normal, italic, bold, or bold italic text of various sizes and font styles.

Which I assume should be implemented as:

> This sample text attempts to visually demonstrate how readable this color combination is, for normal, _italic_, **bold**, or **_bold italic_** text of various sizes and font styles.

This removed the paragraph that was added, and instead modifies the original sentence with your revised version.

This does however also change the use of [`<strong>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong) favoring the [`font-weight`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property via CSS for similar reasons as [`font-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) should be used instead of [`<em>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em).

![image](https://user-images.githubusercontent.com/22801583/97816365-01277500-1c95-11eb-9b8b-20697f3a1106.png)

Edit: Not 100% sure, so not acting on it yet, but also just wanted to check should it be: "or bold italic"? :thinking: I think "and bold italic" might be more appropriate? (Since you're showcasing all of them at once.)