### PR TITLE
Add Information about Non-Text Contrast

### DIFF
--- a/contrast-ratio.js
+++ b/contrast-ratio.js
@@ -23,10 +23,10 @@ function floor(number, decimals) {
 
 var messages = {
 	"semitransparent": "The background is semi-transparent, so the contrast ratio cannot be precise. Depending on what’s going to be underneath, it could be any of the following:",
-	"fail": "Fails WCAG 2.0 :-(",
-	"aa-large": "Passes AA for large text (above 18pt or bold above 14pt)",
-	"aa": "Passes AA level for any size text and AAA for large text (above 18pt or bold above 14pt)",
-	"aaa": "Passes AAA level for any size text"
+	"fail": "Fails WCAG 2.0 and 2.1 :-(",
+	"aa-large": "Passes AA for large text (above 18pt or bold above 14pt) and AA for user interface components and graphical objects",
+	"aa": "Passes AA level for any size text, AAA for large text (above 18pt or bold above 14pt), and AA for user interface components and graphical objects",
+	"aaa": "Passes AAA level for any size text and AA for user interface components and graphical objects"
 };
 
 var canvas = document.createElement("canvas"),

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 	<p style="font-size: 11pt;"><strong>Hint:</strong> Press the up and down keyboard arrows while over a number inside a functional color notation. Watch it increment/decrement. Try with the Shift or Alt key too!</p>
 	<footer>
 		By <a href="http://lea.verou.me" rel="noopener" target="_blank">Lea Verou</a>
-		&bull; <a href="https://www.w3.org/TR/WCAG/#contrast-minimum" rel="noopener" target="_blank">WCAG 2.0 on contrast ratio</a>
+		&bull; <a href="https://www.w3.org/TR/WCAG/#contrast-minimum" rel="noopener" target="_blank">WCAG 2.1 on contrast ratio</a>
 
 	</footer>
 </section>


### PR DESCRIPTION
This is a small change that adds information about [WCAG 2.1 Non-Text Contrast](https://www.w3.org/TR/WCAG/#x1-4-11-non-text-contrast) criteria. Non-text contrast is a new requirement in WCAG 2.1.

Because WCAG 2.1 requires a contrast ratio of 3:1 for this content, it matches the existing AA criteria for large text, so the only changes required was an update to the language.

I also updated the text of the WCAG link from 2.0 to 2.1 as that is where the link points and is the current recommendation.