### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+curly_bracket_next_line = false
+spaces_around_operators = true
+
+# Tabs have been outlawed since they are treated differently by different editors and tools.
+# — https://yaml.org/faq.html
+[*.{yaml,yml}]
+indent_style = space

--- a/color.js
+++ b/color.js
@@ -69,23 +69,23 @@ _.prototype = {
 		return 'rgb' + (this.alpha < 1? 'a' : '') + '(' + this.rgba.slice(0, this.alpha >= 1? 3 : 4).join(', ') + ')';
 	},
 
-  /**
- * @param {boolean} withAlpha If the output should include the alpha channel.
- * @returns {string} A hex color string in the format `#RRGGBB` or `#RRGGBBAA.
- */
-  toHex: function(withAlpha = true) {
-    var [ r, g, b, a ] = this.rgba;
-    var uint8ToHex = function(uint8) { return uint8.toString(16).padStart(2, '0'); }
+	/**
+	 * @param {boolean} withAlpha If the output should include the alpha channel.
+	 * @returns {string} A hex color string in the format `#RRGGBB` or `#RRGGBBAA.
+	 */
+	toHex: function(withAlpha = true) {
+		var [ r, g, b, a ] = this.rgba;
+		var uint8ToHex = function(uint8) { return uint8.toString(16).padStart(2, '0'); }
 
-    var result = `#${uint8ToHex(r)}${uint8ToHex(g)}${uint8ToHex(b)}`;
+		var result = `#${uint8ToHex(r)}${uint8ToHex(g)}${uint8ToHex(b)}`;
 
-    if (withAlpha) {
-      var aHex = uint8ToHex(a * 255);
-      result += aHex;
-    }
+		if (withAlpha) {
+			var aHex = uint8ToHex(a * 255);
+			result += aHex;
+		}
 
-    return result;
-  },
+		return result;
+	},
 
 	clone: function() {
 		return new _(this.rgba);


### PR DESCRIPTION
While developing for this, there can be some annoyances with different code styles.
Namely, tabs vs spaces. ^-^'

Could an EditorConfig file be included? It has fairly wide support, so when contributors want to do their thing, the editor settings will automatically apply the conventions already used in the repository.

The `_config.yml` file is just so GitHub Pages doesn't host it on the site.