### PR TITLE
fix: remove color change on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,7 +171,6 @@ label {
 	}
 
 	.color-display a:hover {
-		color: black;
 		text-decoration: underline;
 	}
 


### PR DESCRIPTION
Because of the nature/implementation of the website, I think it's best if the color of your links at the bottom of the text doesn't change on hover.

Users will already see their cursor change to pointer and an underline when they hover, think that's fine? If you want more, I can also have some fun with opacity, so it lights up a bit.

### Before

![link-colors-before](https://user-images.githubusercontent.com/22801583/197348530-216c1a29-f219-45be-b067-dc09a9b5fcf7.gif)

### After

![link-colors](https://user-images.githubusercontent.com/22801583/197348528-1263a73c-dd09-4f61-bbbc-b238a5b5fd41.gif)

